### PR TITLE
change feature expression: :apple -> :ccl

### DIFF
--- a/constraints.lisp
+++ b/constraints.lisp
@@ -97,7 +97,7 @@
   latter case, the other formula is made the parent, and this function
   creates an inherited formula.  The <initial-value>, which defaults to nil,
   is used as the initial cached value before the formula is evaluated."
-  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
     (let ((formula (make-new-formula)))
     (setf (schema-name formula) (incf *schema-counter*))
     (setf (cached-value formula) initial-value)
@@ -120,9 +120,9 @@
 	(setf (a-formula-function formula)
 	      ;; This version does not work with CL version 2.  It is,
 	      ;; however, much more efficient than calling the compiler.
-	      #-(or CMU APPLE ANSI-CL) `(lambda () ,form)
+	      #-(or CMU CCL ANSI-CL) `(lambda () ,form)
 	      ;; This version works with CL version 2.
-	      #+(or CMU APPLE ANSI-CL) (compile nil `(lambda () ,form)))
+	      #+(or CMU CCL ANSI-CL) (compile nil `(lambda () ,form)))
 	(setf (a-formula-lambda formula) form)))
     formula)))
 
@@ -141,7 +141,7 @@
 
 
 (defun prepare-formula (initial-value)
-  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
   (let ((formula (make-new-formula)))
     (setf (schema-name formula) (incf *schema-counter*))
     (setf (cached-value formula) initial-value)
@@ -374,7 +374,7 @@
 ;;; dependencies at the end.
 ;;;
 (defun gv-value-fn (schema slot)
-  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
   #+GARNET-DEBUG
   (unless (or *current-formula* (schema-p schema))
     (cerror "Return NIL" "  GV attempted on the non-object ~S (slot ~S)."
@@ -755,7 +755,7 @@ Found in the expression   (gv ~S~{ ~S~}) ,~:[
 ;;; dotted pairs, where each pair consists of a schema and a slot.
 ;;;
 (defun i-depend-on (object slot)
-  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
   (if (schema-p object)
     (let ((formula (get-value object slot))
 	  (dependencies nil))

--- a/kr-macros.lisp
+++ b/kr-macros.lisp
@@ -54,17 +54,17 @@
 
 (eval-when (eval compile load)
   (defvar *special-kr-optimization*
-    '(optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+    '(optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
 
   (proclaim '(special common-lisp-user::*default-garnet-proclaim*))
   (if (boundp 'common-lisp-user::*default-garnet-proclaim*)
     (if common-lisp-user::*default-garnet-proclaim*
       (proclaim common-lisp-user::*default-garnet-proclaim*))
     (proclaim '(optimize (safety 1) (space 0)
-		(speed #-LUCID 3 #+LUCID 2) #+(or APPLE ALLEGRO) (debug 3))
+		(speed #-LUCID 3 #+LUCID 2) #+(or CCL ALLEGRO) (debug 3))
 	      #+COMMENT
 	      '(optimize (safety 0) (space 0)
-		(speed #-LUCID 3 #+LUCID 2) #+(or APPLE ALLEGRO) (debug 0)))))
+		(speed #-LUCID 3 #+LUCID 2) #+(or CCL ALLEGRO) (debug 0)))))
 
 
 ;;; This enables the eager-evaluation version.
@@ -1097,7 +1097,7 @@ You can also provide a documentation string as the last parameter, as in:
 ;;;; GET-LOCAL-VALUE
 ;;; 
 (defun get-local-value (schema slot)
-  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
     (let ((entry (slot-accessor schema slot)))
     (if (if entry (not (is-inherited (sl-bits entry))))
       (sl-value entry)))))
@@ -1371,7 +1371,7 @@ You can also provide a documentation string as the last parameter, as in:
 ;;; Helper function for multi-level S-VALUE
 ;;;
 (defun s-value-chain (schema &rest slots)
-  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
   (if (null schema)
     (error "S-VALUE on a null object:  (S-VALUE ~S~{ ~S~})" schema slots)
     (unless (schema-p schema)
@@ -1490,7 +1490,7 @@ at slot ~S  (non-schema value is ~S, last schema was ~S)"
 ;;;; HAS-SLOT-P
 ;;; 
 (defun has-slot-p (schema slot)
-  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO APPLE) (debug 0)))
+  (locally (declare (optimize (speed 3) (space 0) #+(or ALLEGRO CCL) (debug 0)))
     (let ((entry (slot-accessor schema slot)))
     (if entry
       (if (not (eq (sl-value entry) *no-value*))

--- a/kr.lisp
+++ b/kr.lisp
@@ -51,10 +51,10 @@
       (if common-lisp-user::*default-garnet-proclaim*
         (proclaim common-lisp-user::*default-garnet-proclaim*))
       (proclaim '(optimize (safety 1) (space 0)
-		  (speed #-LUCID 3 #+LUCID 2) #+(or ALLEGRO APPLE) (debug 3))
+		  (speed #-LUCID 3 #+LUCID 2) #+(or ALLEGRO CCL) (debug 3))
 		#+COMMENT
 		'(optimize (safety 0) (space 0)
-		  (speed #-LUCID 3 #+LUCID 2) #+(or ALLEGRO APPLE) (debug 0)))))
+		  (speed #-LUCID 3 #+LUCID 2) #+(or ALLEGRO CCL) (debug 0)))))
 
 
 
@@ -688,7 +688,7 @@
 	   `(function (lambda (value)
 	      (declare (optimize (safety 0) (space 0)
 				 (speed #-LUCID 3 #+LUCID 2)
-                                 #+(or APPLE ALLEGRO) (debug 0)))
+                                 #+(or CCL ALLEGRO) (debug 0)))
 	      ,(make-lambda-body type)))))
 	((setq code (gethash (symbol-name type) types-table))
 	 ;; is this a def-kr-type?
@@ -2668,7 +2668,7 @@
 ;;;
 (defun do-schema-body (schema is-a generate-instance do-constants override
 			      types &rest slot-specifiers)
-  (when #+apple (typep is-a 'ccl::immediate) #-apple (equal is-a '(nil))
+  (when #+ccl (typep is-a 'ccl::immediate) #-ccl (equal is-a '(nil))
     (format
      t
      "*** (create-instance ~S) called with an illegal (unbound?) class name.~%"


### PR DESCRIPTION
I guess feature expression `:apple` meant MCL(Macintosh CL) in original code written in those days.
`:apple` feature expression causes a bit trouble in not MCL in build time.
And some of implementation of nowadays like LispWorks has `:apple` in feature expression.
So, I took `:ccl` feature expression instead of `:apple`.
Because CCL(Clozure CL) is the decendent of MCL.
Thank you.